### PR TITLE
Increase upper version bound on `base`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ cabal-dev
 dist_*
 history
 TAGS
+.cabal-sandbox
+cabal.sandbox.config

--- a/vector-space-points.cabal
+++ b/vector-space-points.cabal
@@ -18,7 +18,7 @@ source-repository head
 
 library
   exposed-modules:     Data.AffineSpace.Point
-  build-depends:       base >=4.0 && < 4.8,
+  build-depends:       base >=4.0 && < 4.9,
                        vector-space >=0.7 && < 0.10
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This makes it possible to install `vector-space-points` with GHC 7.10.1.